### PR TITLE
Only pull active users on sync

### DIFF
--- a/src/lpconnector/commands/sync.py
+++ b/src/lpconnector/commands/sync.py
@@ -33,7 +33,7 @@ class Sync(BaseCommand):    # pylint: disable=too-few-public-methods
             print("Syncing ALL users to LastPass...")
             self.ldap_users = self.ldap_server.get_all_users()
             print("Retrieving " + str(len(self.ldap_users)) + " LDAP Users...")
-            self.lastpass_users = self.lp_client.get_user_data()
+            self.lastpass_users = self.lp_client.get_user_data(disabled=0)
         else:
             if self.args.get('--users') is not None:
                 users = self.args.get('--users').split(',')


### PR DESCRIPTION
Previously on sync, it would pull all users out of the lastpass directory even if they were disabled. This change makes it so you're only pulling active users from LP on sync